### PR TITLE
Enable/Disable Gender Background Colours

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ NOTE 1: When adding reference links from one record to another, I recommend to a
 
 NOTE 2: You can hide the UID values in the module's configuration in webtree's Control panel.
 
+NOTE 3: You can Enable/Disable WebTrees Gender background Colours for this module in the module's configuration in webtree's Control panel. (the actual colours are set in WebTrees CSS and or Themes CSS NOT in this module)
+
 Installation & upgrading
 ------------------------
 Unpack the zip file and place the mitalteli-show-xref folder in the modules_v4 folder of webtrees. Upload the newly added folder to your server. It is activated by default and will work immediately. No additional configuration is required.

--- a/ShowXrefModule.php
+++ b/ShowXrefModule.php
@@ -190,6 +190,7 @@ class ShowXrefModule extends AbstractModule implements ModuleCustomInterface, Mo
         return view($this->name() . '::sidebar-header', [
             'module'   => $this,
             'with_uid' => $this->getPreference('with-uid', '1'),
+            'with_css' => $this->getPreference('with-css', '1'),
             'is_admin' => Auth::isAdmin(),
         ]);
     }
@@ -234,6 +235,7 @@ class ShowXrefModule extends AbstractModule implements ModuleCustomInterface, Mo
             'module'          => $this,
             'module_basename' => $this->name(),
             'with_uid'        => $this->getPreference('with-uid', '1'),
+            'with_css'        => $this->getPreference('with-css', '1'),
         ]);
     }
 
@@ -251,6 +253,7 @@ class ShowXrefModule extends AbstractModule implements ModuleCustomInterface, Mo
         return $this->viewResponse($this->name() . '::settings', [
             'expand_sidebar' => $this->getPreference('expand-sidebar'),
             'with_uid'       => $this->getPreference('with-uid', '1'),
+            'with_css'       => $this->getPreference('with-css', '1'),
             'sidebar_order'  => $this->getPreference('sidebar-order', '10'),
             'title'          => $this->title(),
         ]);
@@ -270,6 +273,7 @@ class ShowXrefModule extends AbstractModule implements ModuleCustomInterface, Mo
         if ($params['save'] === '1') {
             $this->setPreference('expand-sidebar', $params['expand-sidebar'] ?? '0');
             $this->setPreference('with-uid', $params['with-uid'] ?? '0');
+            $this->setPreference('with-css', $params['with-css'] ?? '0');
             $this->setPreference('sidebar-order', $params['sidebar-order'] ?? '10');
 
             $message = I18N::translate('The preferences for the module “%s” have been updated.', $this->title());

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -1,7 +1,10 @@
     th.mitalteli-show-xref-label {
-        width: 4em
+        width: 4em;
     }
     .uid {
         font-size: x-small;
         text-align: center;
     }
+	.show-xref-notset {
+		color: red;
+	}

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -12,12 +12,14 @@
     "Include UID values" => 'UID-Werte einbeziehen', // resources/views/settings.phtml
     'Sidebar order' => 'Seitenleistenreihenfolge', // resources/views/settings.phtml
     "save" => 'sichern', // resources/views/settings.phtml
+    "Enable/Disable CSS Gender Background Colors" => 'Aktivieren/Deaktivieren von CSS-Hintergrundfarben für das Geschlecht', // resources/views/settings.phtml
     "XREF and UID information" => 'XREF- und UID-Werte', // resources/views/sidebar-header.phtml
     "XREF information" => 'XREF Werte', // resources/views/sidebar-header.phtml - Line 13 - title of sidebar
     #'Private' => 'Private', // resources/views/sidebar-xref.phtml
     #'Parents' => 'Parents', // resources/views/sidebar-xref.phtml
     #'Family' => 'Family', // resources/views/sidebar-xref.phtml
     "UID information is disabled." => 'Anzeige von UID ist deaktiviert.', // resources/views/sidebar.phtml - Line 13 - title of sidebar
+    "CSS gender background colors are disabled." => 'CSS-Hintergrundfarben für das Geschlecht sind deaktiviert.', // resources/views/sidebar.phtml - Line 33
     #'Individual' => 'Individual', // resources/views/sidebar.phtml
     #'Step children' => 'Step children', // resources/views/sidebar.phtml
 

--- a/resources/lang/de.php
+++ b/resources/lang/de.php
@@ -19,7 +19,7 @@
     #'Parents' => 'Parents', // resources/views/sidebar-xref.phtml
     #'Family' => 'Family', // resources/views/sidebar-xref.phtml
     "UID information is disabled." => 'Anzeige von UID ist deaktiviert.', // resources/views/sidebar.phtml - Line 13 - title of sidebar
-    "CSS gender background colors are disabled." => 'CSS-Hintergrundfarben für das Geschlecht sind deaktiviert.', // resources/views/sidebar.phtml - Line 33
+    "Gender background colors are disabled." => 'Hintergrundfarben für das Geschlecht sind deaktiviert.', // resources/views/sidebar.phtml - Line 33
     #'Individual' => 'Individual', // resources/views/sidebar.phtml
     #'Step children' => 'Step children', // resources/views/sidebar.phtml
 

--- a/resources/lang/en-AU.php
+++ b/resources/lang/en-AU.php
@@ -1,0 +1,9 @@
+<?php
+
+    return [
+
+    "Enable/Disable CSS Gender Background Colors" => 'Enable/Disable CSS Gender Background Colours', // resources/views/settings.phtml
+    "CSS gender background colors are disabled." => 'CSS Gender Background Colours are Disabled.', // resources/views/sidebar.phtml - Line 33
+
+    ];
+?>

--- a/resources/lang/en-AU.php
+++ b/resources/lang/en-AU.php
@@ -3,7 +3,7 @@
     return [
 
     "Enable/Disable CSS Gender Background Colors" => 'Enable/Disable CSS Gender Background Colours', // resources/views/settings.phtml
-    "CSS gender background colors are disabled." => 'CSS Gender Background Colours are Disabled.', // resources/views/sidebar.phtml - Line 33
+    "Gender background colors are disabled." => 'Gender Background Colours are Disabled.', // resources/views/sidebar.phtml - Line 33
 
     ];
 ?>

--- a/resources/lang/en-GB.php
+++ b/resources/lang/en-GB.php
@@ -1,0 +1,9 @@
+<?php
+
+    return [
+
+    "Enable/Disable CSS Gender Background Colors" => 'Enable/Disable CSS Gender Background Colours', // resources/views/settings.phtml
+    "CSS gender background colors are disabled." => 'CSS Gender Background Colours are Disabled.', // resources/views/sidebar.phtml - Line 33
+
+    ];
+?>

--- a/resources/lang/en-GB.php
+++ b/resources/lang/en-GB.php
@@ -3,7 +3,7 @@
     return [
 
     "Enable/Disable CSS Gender Background Colors" => 'Enable/Disable CSS Gender Background Colours', // resources/views/settings.phtml
-    "CSS gender background colors are disabled." => 'CSS Gender Background Colours are Disabled.', // resources/views/sidebar.phtml - Line 33
+    "Gender background colors are disabled." => 'Gender Background Colours are Disabled.', // resources/views/sidebar.phtml - Line 33
 
     ];
 ?>

--- a/resources/lang/es.php
+++ b/resources/lang/es.php
@@ -12,8 +12,8 @@
     "Include UID values" => 'Incluir valores UID', // resources/views/settings.phtml
     'Sidebar order' => 'Orden de la barra lateral', // resources/views/settings.phtml
     "save" => 'guardar', // resources/views/settings.phtml
-    "Enable/Disable CSS Gender Background Colors" => 'Activar/desactivar los colores de fondo del género CSS', // resources/views/settings.phtml
-    "CSS gender background colors are disabled." => 'Los colores de fondo del género CSS están desactivados.', // resources/views/sidebar.phtml - Line 33
+    "Enable/Disable CSS Gender Background Colors" => 'Activar/desactivar los CSS para colores de fondo según género', // resources/views/settings.phtml
+    "Gender background colors are disabled." => 'Los colores de fondo por género están desactivados.', // resources/views/sidebar.phtml - Line 33
     "XREF and UID information" => 'Información de valores XREF y UID', // resources/views/sidebar.phtml - Line 13 - title of sidebar
     "XREF information" => 'Información de valores XREF', // resources/views/sidebar-header.phtml - Line 13 - title of sidebar
     #'Private' => 'Private', // resources/views/sidebar-xref.phtml

--- a/resources/lang/es.php
+++ b/resources/lang/es.php
@@ -12,6 +12,8 @@
     "Include UID values" => 'Incluir valores UID', // resources/views/settings.phtml
     'Sidebar order' => 'Orden de la barra lateral', // resources/views/settings.phtml
     "save" => 'guardar', // resources/views/settings.phtml
+    "Enable/Disable CSS Gender Background Colors" => 'Activar/desactivar los colores de fondo del género CSS', // resources/views/settings.phtml
+    "CSS gender background colors are disabled." => 'Los colores de fondo del género CSS están desactivados.', // resources/views/sidebar.phtml - Line 33
     "XREF and UID information" => 'Información de valores XREF y UID', // resources/views/sidebar.phtml - Line 13 - title of sidebar
     "XREF information" => 'Información de valores XREF', // resources/views/sidebar-header.phtml - Line 13 - title of sidebar
     #'Private' => 'Private', // resources/views/sidebar-xref.phtml

--- a/resources/views/settings.phtml
+++ b/resources/views/settings.phtml
@@ -30,6 +30,10 @@ use Fisharebest\Webtrees\Http\RequestHandlers\ControlPanel;
             <div>
                 <?= view('components/checkbox', ['label' => I18N::translate('Include UID values'), 'name' => 'with-uid', 'checked' => (bool) $with_uid]) ?>
             </div>
+            <!-- USE CSS COLOURS FOR BACKGROUND -->
+            <div>
+                <?= view('components/checkbox', ['label' => I18N::translate('Enable/Disable CSS Gender Background Colors'), 'name' => 'with-css', 'checked' => (bool) $with_css]) ?>
+            </div>
 
             <label class="col-sm-3 col-form-label wt-page-options-label" for="sidebar-order">
                 <?= I18N::translate('Sidebar order') ?>

--- a/resources/views/sidebar-header.phtml
+++ b/resources/views/sidebar-header.phtml
@@ -6,6 +6,7 @@ use Fisharebest\Webtrees\View;
 /*
  * @var ShowXrefModule $this,
  * @var bool           $with_uid
+ * @var bool           $with_css
  */
 
 ?>

--- a/resources/views/sidebar-xref.phtml
+++ b/resources/views/sidebar-xref.phtml
@@ -12,7 +12,6 @@ use Fisharebest\Webtrees\Services\RelationshipService;
  * @var Family     $family
  * @var string     $title
  * @var boolean    $with_uid
- * @var string     $spouse
  */
 
 ?>

--- a/resources/views/sidebar-xref.phtml
+++ b/resources/views/sidebar-xref.phtml
@@ -12,11 +12,12 @@ use Fisharebest\Webtrees\Services\RelationshipService;
  * @var Family     $family
  * @var string     $title
  * @var boolean    $with_uid
+ * @var boolean    $with_css
  */
 
 ?>
 
-<table class="table table-sm wt-facts-table wt-family-navigator-family">
+<table class="table table-sm wt-facts-table wt-family-navigator-family mitalteli-show-xref-table">
     <caption class="text-center wt-family-navigator-family-heading">
         <?php if (empty($family)) : ?>
             <!-- the individual itself -->
@@ -29,8 +30,11 @@ use Fisharebest\Webtrees\Services\RelationshipService;
     <tbody>
         <?php if (empty($family)) : ?>
             <!-- the individual itself -->
+			<?php if (empty($with_css)) : ?>
+			<tr class="text-center wt-family-navigator-parent">
+			<?php else : ?>
             <tr class="text-center wt-family-navigator-parent wt-sex-<?= strtolower($individual->sex()) ?>">
-
+			<?php endif ?>
                 <?php if ($individual->canShow()) : ?>
                     <th class="align-middle mitalteli-show-xref-label" scope="row">
                          <?= $individual->xref() ?>
@@ -51,7 +55,11 @@ use Fisharebest\Webtrees\Services\RelationshipService;
             </tr>
         <?php else : ?>
             <?php foreach ($family->spouses() as $spouse) : ?>
+				<?php if (empty($with_css)) : ?>
+                <tr class="text-center wt-family-navigator-parent">
+				<?php else : ?>
                 <tr class="text-center wt-family-navigator-parent wt-sex-<?= strtolower($spouse->sex()) ?>">
+				<?php endif ?>
                     <th class="align-middle mitalteli-show-xref-label" scope="row">
                         <?php if ($spouse === $individual) : ?>
                             <?= $spouse->xref() ?>
@@ -92,7 +100,11 @@ use Fisharebest\Webtrees\Services\RelationshipService;
             <?php endforeach ?>
     
             <?php foreach ($family->children() as $child) : ?>
+				<?php if (empty($with_css)) : ?>
+                <tr class="text-center wt-family-navigator-child">
+				<?php else : ?>
                 <tr class="text-center wt-family-navigator-child wt-sex-<?= strtolower($child->sex()) ?>">
+				<?php endif ?>
                     <th class="align-middle mitalteli-show-xref-label" scope="row">
                         <?php if ($child === $individual) : ?>
                             <?= $child->xref() ?>

--- a/resources/views/sidebar-xref.phtml
+++ b/resources/views/sidebar-xref.phtml
@@ -12,6 +12,7 @@ use Fisharebest\Webtrees\Services\RelationshipService;
  * @var Family     $family
  * @var string     $title
  * @var boolean    $with_uid
+ * @var string     $spouse
  */
 
 ?>
@@ -29,7 +30,7 @@ use Fisharebest\Webtrees\Services\RelationshipService;
     <tbody>
         <?php if (empty($family)) : ?>
             <!-- the individual itself -->
-            <tr class="text-center wt-family-navigator-parent">
+            <tr class="text-center wt-family-navigator-parent wt-sex-<?= strtolower($individual->sex()) ?>">
 
                 <?php if ($individual->canShow()) : ?>
                     <th class="align-middle mitalteli-show-xref-label" scope="row">
@@ -51,7 +52,7 @@ use Fisharebest\Webtrees\Services\RelationshipService;
             </tr>
         <?php else : ?>
             <?php foreach ($family->spouses() as $spouse) : ?>
-                <tr class="text-center wt-family-navigator-parent">
+                <tr class="text-center wt-family-navigator-parent wt-sex-<?= strtolower($spouse->sex()) ?>">
                     <th class="align-middle mitalteli-show-xref-label" scope="row">
                         <?php if ($spouse === $individual) : ?>
                             <?= $spouse->xref() ?>
@@ -92,7 +93,7 @@ use Fisharebest\Webtrees\Services\RelationshipService;
             <?php endforeach ?>
     
             <?php foreach ($family->children() as $child) : ?>
-                <tr class="text-center wt-family-navigator-child">
+                <tr class="text-center wt-family-navigator-child wt-sex-<?= strtolower($child->sex()) ?>">
                     <th class="align-middle mitalteli-show-xref-label" scope="row">
                         <?php if ($child === $individual) : ?>
                             <?= $child->xref() ?>

--- a/resources/views/sidebar.phtml
+++ b/resources/views/sidebar.phtml
@@ -11,6 +11,7 @@ use Fisharebest\Webtrees\Individual;
  * @var Tree       $tree
  * @var string     $module_basename
  * @var bool       $with_uid
+ * @var bool       $with_css
  */
 ?>
 
@@ -23,18 +24,22 @@ use Fisharebest\Webtrees\Individual;
     ?>
     <div class="show-xref-area mb-3">
         <div class="wt-sidebar-content wt-sidebar-family-navigator">
-            <table class="table table-sm wt-facts-table wt-family-navigator-family">
-                <tbody>
+            <div class="show-xref-settings">
                     <?php if (! $with_uid) : ?>  <!-- # HOPE TO IMPLEMENT CONFIGURATION INTERFACE TO DEFINE IF SHOWN XREF, UID OR BOTH -->
-                        <span class="uid"><?= I18N::translate("UID information is disabled.") ?></span>
+                        <span class="show-xref-notset"><?= I18N::translate("UID information is disabled.") ?></span>
                     <?php endif ?>
-    
+                     <?php if (! $with_css) : ?>  <!-- # CSS Classes not Set -->
+                        <span class="show-xref-notset"><br><?= I18N::translate("CSS gender background colors are disabled.") ?></span>
+                    <?php endif ?>
+			</div>
+   
                     <!-- the individual itself -->
                     <?= view($module_basename . '::sidebar-xref', [
                         'module'     => $module,
                         'individual' => $individual, 
                         'title'      => I18N::translate('Individual'), 
                         'with_uid'   => $with_uid,
+                        'with_css'   => $with_css,
                     ]) ?>
     
                     <!-- parent families -->
@@ -45,6 +50,7 @@ use Fisharebest\Webtrees\Individual;
                             'family'     => $family, 
                             'title'      => $individual->getChildFamilyLabel($family), 
                             'with_uid'   => $with_uid,
+							'with_css'   => $with_css,
                         ]) ?>
                     <?php endforeach ?>
                 
@@ -56,6 +62,7 @@ use Fisharebest\Webtrees\Individual;
                             'family'     => $family, 
                             'title'      => $individual->getStepFamilyLabel($family), 
                             'with_uid'   => $with_uid,
+							'with_css'   => $with_css,
                         ]) ?>
                     <?php endforeach ?>
                 
@@ -67,6 +74,7 @@ use Fisharebest\Webtrees\Individual;
                             'family'     => $family, 
                             'title'      => $individual->getSpouseFamilyLabel($family), 
                             'with_uid'   => $with_uid,
+							'with_css'   => $with_css,
                         ]) ?>
                     <?php endforeach ?>
                 
@@ -77,11 +85,10 @@ use Fisharebest\Webtrees\Individual;
                             'individual' => $individual, 
                             'family' => $family, 
                             'title' => I18N::translate('Step children'), 
-                            'with_uid' => $with_uid
+                            'with_uid' => $with_uid,
+							'with_css'   => $with_css
                         ]) ?>
                     <?php endforeach ?>
-                </tbody>
-            </table>
         </div>
     </div>
 </div>

--- a/resources/views/sidebar.phtml
+++ b/resources/views/sidebar.phtml
@@ -29,7 +29,7 @@ use Fisharebest\Webtrees\Individual;
                         <span class="show-xref-notset"><?= I18N::translate("UID information is disabled.") ?></span>
                     <?php endif ?>
                      <?php if (! $with_css) : ?>  <!-- # CSS Classes not Set -->
-                        <span class="show-xref-notset"><br><?= I18N::translate("CSS gender background colors are disabled.") ?></span>
+                        <span class="show-xref-notset"><br><?= I18N::translate("Gender background colors are disabled.") ?></span>
                     <?php endif ?>
 			</div>
    


### PR DESCRIPTION
Allows one to enable or disable the Webtrees Gender background colours as seen in the Family Navigator Sidebar Module.

Added GB and AU language files and updated es and de language files.

Added some extra classes to allow module specific css changes.